### PR TITLE
Feature/server

### DIFF
--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -33,13 +33,14 @@ class LoggingServer(socketserver.ThreadingTCPServer):
 
     def start(self):
         self.server_thread = threading.Thread(target=self.serve_until_stopped)
+        self.server_thread.start()
         self.logger.info("About starting LoggingServer...")
 
     def shutdown(self,timeout:float=0.0):
         self.__shutdown.value = True
         self.server_thread.join(timeout)
         self.logger.info("Shutdown Logging Server.")
-        
+
 
 
 

--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -17,6 +17,7 @@ class LoggingServer(socketserver.ThreadingTCPServer):
         self.abort = 0
         self.timeout = 1
         self.logname = None
+        self.logger = logging.getLogger()
     
     def serve_until_stopped(self,shutdown):
         import select

--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -2,11 +2,8 @@ from .handlers import LogRecordStreamHandler
 import socketserver
 import logging
 import logging.handlers
-from dataclasses import dataclass
 import threading
-@dataclass
-class Shutdown:
-    value:bool = False
+
 class LoggingServer(socketserver.ThreadingTCPServer):
     """The SocketServer which receive Logs."""
 
@@ -19,29 +16,32 @@ class LoggingServer(socketserver.ThreadingTCPServer):
         self.timeout = 1
         self.logname = None
         self.logger = logging.getLogger()
-        self.__shutdown = Shutdown(False)
+        self.__shutdown = False
         self.server_thread:threading.Thread = None
 
     def serve_until_stopped(self):
         import select
         abort = 0
-        while not abort and not self.__shutdown.value:
+        while not abort and not self.__shutdown:
             rd, wr, ex = select.select([self.socket.fileno()], [], [], self.timeout)
             if rd:
                 self.handle_request()
             abort = self.abort
 
     def start(self):
-        self.server_thread = threading.Thread(target=self.serve_until_stopped)
+        self.__shutdown= False
+        self.server_thread = threading.Thread(target=self.serve_until_stopped,daemon=True)
         self.server_thread.start()
         self.logger.info("About starting LoggingServer...")
 
     def shutdown(self,timeout:float=0.0):
-        self.__shutdown.value = True
+        self.__shutdown = True
         self.server_thread.join(timeout)
         self.logger.info("Shutdown Logging Server.")
 
-
+    def __del__(self):
+        self.shutdown()
+        
 
 
         

--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -2,8 +2,11 @@ from .handlers import LogRecordStreamHandler
 import socketserver
 import logging
 import logging.handlers
+from dataclasses import dataclass
 import threading
-
+@dataclass
+class Shutdown:
+    value:bool = False
 class LoggingServer(socketserver.ThreadingTCPServer):
     """The SocketServer which receive Logs."""
 
@@ -16,33 +19,29 @@ class LoggingServer(socketserver.ThreadingTCPServer):
         self.timeout = 1
         self.logname = None
         self.logger = logging.getLogger()
-        self.__shutdown = False
+        self.__shutdown = Shutdown(False)
         self.server_thread:threading.Thread = None
 
     def serve_until_stopped(self):
         import select
         abort = 0
-        while not abort and not self.__shutdown:
+        while not abort and not self.__shutdown.value:
             rd, wr, ex = select.select([self.socket.fileno()], [], [], self.timeout)
             if rd:
                 self.handle_request()
             abort = self.abort
 
     def start(self):
-        self.__shutdown= False
-        self.server_thread = threading.Thread(target=self.serve_until_stopped,daemon=True)
+        self.server_thread = threading.Thread(target=self.serve_until_stopped)
         self.server_thread.start()
         self.logger.info("About starting LoggingServer...")
 
     def shutdown(self,timeout:float=0.0):
-        self.__shutdown = True
+        self.__shutdown.value = True
         self.server_thread.join(timeout)
         self.logger.info("Shutdown Logging Server.")
 
-    def __del__(self):
-        self.shutdown()
-        
-        
+
 
 
         

--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -2,7 +2,10 @@ from .handlers import LogRecordStreamHandler
 import socketserver
 import logging
 import logging.handlers
-
+from dataclasses import dataclass
+@dataclass
+class Shutdown:
+    value:bool = False
 class LoggingServer(socketserver.ThreadingTCPServer):
     """The SocketServer which receive Logs."""
 

--- a/logging_server/server.py
+++ b/logging_server/server.py
@@ -1,0 +1,25 @@
+from .handlers import LogRecordStreamHandler
+import socketserver
+import logging
+import logging.handlers
+
+class LoggingServer(socketserver.ThreadingTCPServer):
+    """The SocketServer which receive Logs."""
+
+    allow_reuse_address = True
+
+    def __init__(self,host='localhost',port=logging.handlers.DEFAULT_TCP_LOGGING_PORT, 
+                handler=LogRecordStreamHandler):
+        super().__init__((host, port), handler)
+        self.abort = 0
+        self.timeout = 1
+        self.logname = None
+    
+    def serve_until_stopped(self,shutdown):
+        import select
+        abort = 0
+        while not abort and not shutdown.value:
+            rd, wr, ex = select.select([self.socket.fileno()], [], [], self.timeout)
+            if rd:
+                self.handle_request()
+            abort = self.abort

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,13 +2,25 @@ from logging_server.server import LoggingServer
 import logging
 import sys
 import time
-
+ls = LoggingServer(port=8316)
 def test_start():
-    ls = LoggingServer()
+    global ls
     sh = logging.StreamHandler(sys.stdout)
     ls.logger.addHandler(sh)
     ls.logger.setLevel(0)
     ls.start()
     time.sleep(0.5)
     ls.shutdown()
-    
+
+
+def test_delete_shutdown():
+    global ls
+    ls.start()
+    time.sleep(0.5)
+    del ls
+
+def test_auto_shutdown():
+    ls = LoggingServer(port=12345)
+    ls.start()
+    time.sleep(0.5)
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,14 @@
+from logging_server.server import LoggingServer
+import logging
+import sys
+import time
+
+def test_start():
+    ls = LoggingServer()
+    sh = logging.StreamHandler(sys.stdout)
+    ls.logger.addHandler(sh)
+    ls.logger.setLevel(0)
+    ls.start()
+    time.sleep(0.5)
+    ls.shutdown()
+    

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,25 +2,13 @@ from logging_server.server import LoggingServer
 import logging
 import sys
 import time
-ls = LoggingServer(port=8316)
+
 def test_start():
-    global ls
+    ls = LoggingServer()
     sh = logging.StreamHandler(sys.stdout)
     ls.logger.addHandler(sh)
     ls.logger.setLevel(0)
     ls.start()
     time.sleep(0.5)
     ls.shutdown()
-
-
-def test_delete_shutdown():
-    global ls
-    ls.start()
-    time.sleep(0.5)
-    del ls
-
-def test_auto_shutdown():
-    ls = LoggingServer(port=12345)
-    ls.start()
-    time.sleep(0.5)
-
+    


### PR DESCRIPTION
Almost is copied from https://docs.python.org/ja/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
added interface method:

start()
start server thread.
shutdown()
shutdown server thread.