### PR TITLE
Fix tests/remove stdout

### DIFF
--- a/tests/test_mp_logging.py
+++ b/tests/test_mp_logging.py
@@ -5,10 +5,10 @@ import sys
 import logging
 import time
 
-root = logging.getLogger()
-sh = logging.StreamHandler(sys.stdout)
-root.addHandler(sh)
-root.setLevel(0)
+#root = logging.getLogger()
+#sh = logging.StreamHandler(sys.stdout)
+#root.addHandler(sh)
+#root.setLevel(0)
 
 PORT = 10002
 NUM_PROCESSES = 3

--- a/tests/test_pickled.py
+++ b/tests/test_pickled.py
@@ -4,10 +4,10 @@ import sys, logging
 import time
 from logging import INFO
 
-root = logging.getLogger()
-sh = logging.StreamHandler(sys.stdout)
-root.addHandler(sh)
-root.setLevel(0)
+#root = logging.getLogger()
+#sh = logging.StreamHandler(sys.stdout)
+#root.addHandler(sh)
+#root.setLevel(0)
 
 PORT = 10004
 NUM_PROCESSES = 3


### PR DESCRIPTION
LogCapture was not run normally because I added stdout to root logger. 

Originally, pytest's logcap captures logs without adding stdout, so stdout should not be added to the root logger in the test code.